### PR TITLE
fix: release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'release'
-      - 'release/**'
 
 jobs:
   release:
@@ -18,7 +17,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
 
@@ -33,17 +32,15 @@ jobs:
       - name: Run tests
         run: go test ./...
 
-      - name: Run go-semantic-release
-        uses: go-semantic-release/action@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          release-branches: release
-
-      - name: Prepare dist directory
-        run: mkdir -p dist
+      - name: Run semantic release
+        uses: codfish/semantic-release-action@v2.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SEMREL_BRANCHES: 'release'
 
       - name: Build for multiple platforms
         run: |
+          mkdir -p dist
           platforms=(
             "linux/amd64"
             "linux/arm64"
@@ -60,10 +57,3 @@ jobs:
             fi
             env GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $output ./...
           done
-
-      - name: Upload release assets
-        uses: softprops/action-gh-release@v1
-        with:
-          files: dist/**/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove extra release/** branch from workflow triggers.

Set the Go modules cache key to be more resilient.

Fix semantic release step & add a step to prepare dist directory.

Remove upload step for some reason (hoping blindly trusting AI isn't biting me in the ass)